### PR TITLE
feat: Add confetti transition to "View our menu" button

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,6 +89,7 @@ function setupEventListeners() {
     const modal = document.getElementById('item-modal');
     const closeModalBtn = document.getElementById('close-modal-btn');
     const menuContent = document.getElementById('menu-content');
+    const viewMenuBtn = document.getElementById('view-menu-btn');
 
     closeModalBtn?.addEventListener('click', closeModal);
     modal?.addEventListener('click', (e) => {
@@ -103,6 +104,22 @@ function setupEventListeners() {
             const { itemId, categoryName } = card.dataset;
             openModal(itemId, categoryName);
         }
+    });
+
+    viewMenuBtn?.addEventListener('click', (e) => {
+        e.preventDefault();
+        const jsConfetti = new JSConfetti();
+        jsConfetti.addConfetti({
+            confettiColors: [
+                '#F5F5DC', '#D2B48C', '#3E2723', '#6D4C41', '#D87D4A',
+            ],
+            confettiRadius: 5,
+            confettiNumber: 1000,
+        });
+
+        setTimeout(() => {
+            document.getElementById('menu').scrollIntoView({ behavior: 'smooth' });
+        }, 1000);
     });
 }
 

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
     </div>
 
 
+    <script src="https://cdn.jsdelivr.net/npm/js-confetti@latest/dist/js-confetti.browser.js"></script>
     <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit adds a confetti effect that triggers when the "View our menu" button is clicked. The effect uses the `js-confetti` library to create a visually appealing "explosion" of confetti.

- Added the `js-confetti` library via CDN to `index.html`.
- Implemented an event listener in `app.js` that:
  - Prevents the default anchor link behavior.
  - Triggers the confetti effect with custom colors matching the site's theme.
  - Scrolls to the menu section after a 1-second delay to ensure the animation is visible.