### PR TITLE
Fix mobile navigation bar scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
     <!-- Menu Section -->
     <main id="menu" class="w-full py-16 md:py-24 px-4 md:px-8">
         <nav id="category-nav" class="sticky top-0 z-30 bg-cream/80 backdrop-blur-md py-4 mb-12 shadow-md overflow-x-auto">
-            <div id="category-links" class="max-w-7xl mx-auto flex justify-center items-center gap-4 md:gap-8 px-4">
+            <div id="category-links" class="max-w-7xl mx-auto flex items-center gap-4 md:gap-8 px-4">
                 <!-- Category links will be dynamically inserted here -->
             </div>
         </nav>


### PR DESCRIPTION
The quick navigation bar for menu categories was not fully visible on mobile devices due to the use of `justify-center` on the flex container. This centered the overflowing content and hid the initial categories.

This change removes the `justify-center` class from the `#category-links` div, allowing the content to align to the start. This makes all categories accessible via horizontal scrolling on mobile devices, as intended by the `overflow-x-auto` property.